### PR TITLE
New feature/ Enhancement: Blacklist status codes and halt screen shot process

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ Rules of overriding:
 
   <dt>--options:{option}</dt>
   <dd>Default query parameters. See also "Query parameters" for more details. Example: "--options:width 101"</dd>
+  
+  <dt>--statuscodes value</dt>
+  <dd>Blacklist certain HTTP status response codes, defaults to allowing all status codes from server. Example (to not capture 404 pages and instead return error): "--statuscode 404"</dd>
+  <dd>Example (to not capture 404 or 500 pages and instead return error): "--statuscode 404 --statuscode 500"</dd>
+  <dd>For a large amount of blacklisting, it's better to update the config.json file instead.</dd>
 
 </dl>
 
@@ -143,7 +148,6 @@ Default configuration file *("default.json")*:
 
 ```json
 {
-    "cache": 3600,
     "port": 8891,
     "cors": false,
     "ui": true,
@@ -153,6 +157,11 @@ Default configuration file *("default.json")*:
 
     "engine": "phantomjs",
     "timeout": 60000,
+    "statuscodes": [],
+    "options": {},
+
+    "cache": 3600,
+    "cleanup": false,
 
     "commands": {
         "slimerjs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "manet",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "description": "Website screenshot service powered by Node.js, SlimerJS and PhantomJS",
     "license": "MIT",
 

--- a/src/capture.js
+++ b/src/capture.js
@@ -29,6 +29,7 @@ function cliCommand(config) {
 function cleanupOptions(options, config) {
     var opts = _.omit(options, ['force', 'callback']);
     opts.url = utils.fixUrl(options.url);
+    opts.statuscodes = config.statuscodes;
     return _.defaults(opts, config.options);
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -45,6 +45,10 @@ function createSchema() {
             .integer()
             .min(1)
             .label('Timeout'),
+        statuscodes: joi
+            .array()
+            .default([])
+            .label('Blacklist certain HTTP status response codes, defaults to allowing all status codes from server,'),
         options: joi
             .object()
             .default({})

--- a/src/config/default.json
+++ b/src/config/default.json
@@ -9,6 +9,7 @@
 
     "engine": "phantomjs",
     "timeout": 60000,
+    "statuscodes": [],
     "options": {},
 
     "cache": 3600,


### PR DESCRIPTION
Hello!

Thanks for the great library and wonderful screen shot API.

I've added a feature that I needed and wanted to share it with you - the ability to set an array of HTTP status codes. With these set, if PhantomJs encounters an HTTP response code that matches one set by the user, it will treat the page as invalid and return an error instead of an image.

I needed this feature because I was taking screenshots of pages across my site, and wanted to provide a preview of each document. With this addition, I can be aware of screenshots that failed because the server 404'd or 500'd, and re-process them later.