### PR TITLE
White background as a default stylesheet for rendered pages

### DIFF
--- a/src/scripts/screenshot.js
+++ b/src/scripts/screenshot.js
@@ -131,6 +131,7 @@
                 page = createPage(options);
 
             page.open(options.url, function () {
+                applyDefaultStyle(page);
                 try {
                     renderScreenshotFile(page, options, outputFile, onFinish);
                 } catch (e) {
@@ -142,6 +143,15 @@
         }
     }
 
+    function applyDefaultStyle(page) {
+        page.evaluate(function () {
+            var style = document.createElement('style'),
+                content = document.createTextNode('body { background: #fff }');
+            style.setAttribute('type', 'text/css');
+            style.appendChild(content);
+            document.head.insertBefore(style, document.head.firstChild);
+        });
+    }
 
     /* Fire starter */
 


### PR DESCRIPTION
Some websites do not set the background color relying on browser defaults instead, and it works quite fine because most of the modern browsers will render the background white. However, that's not the case for PhantomJS (at least), which renders the background black, producing bizarre screenshots.

To address this issue I've added a default page stylesheet, consisting of one rule ```body { background: #fff }```

This solution is not universal, of course, I'd say it's more of a hack, but I think it will produce just the desired results most of the time. More accurate approach would be allowing users to specify a stylesheet to apply to the page before screenshot capturing.

What do you think?

Also, I didn't test the solution with SlimerJS because the latter refused to work on my machine.