### PR TITLE
Use cluster.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ Rules of overriding:
 
   <dt>--whitelist</dt>
   <dd>List of <a href="https://github.com/snd/url-pattern">URL patterns</a> that are allowed to be processed by Manet (all URLs are permitted by default).</dd>
+
+  <dt>--workers</dt>
+  <dd>Numbers of workers to start (default is 1).</dd>
 </dl>
 
 ### Configuration file
@@ -162,6 +165,7 @@ Default configuration file *("default.json")*:
     "port": 8891,
     "cors": false,
     "ui": true,
+    "workers" : 1,
 
     "silent": false,
     "level": "info",

--- a/src/config.js
+++ b/src/config.js
@@ -33,6 +33,11 @@ function createSchema() {
         ui: joi
             .boolean()
             .label('Enable sandbox UI'),
+        workers: joi
+            .number()
+            .integer()
+            .min(1)
+            .label('Workers'),
         silent: joi
             .boolean()
             .label('Enable silent mode'),

--- a/src/config/default.json
+++ b/src/config/default.json
@@ -4,6 +4,7 @@
     "port": 8891,
     "cors": false,
     "ui": true,
+    "workers" : 1,
 
     "silent": false,
     "level": "info",


### PR DESCRIPTION
To improve performance I've added support for `cluster`. I thought about using a more advanced library than `cluster`, but I think this will suffice. Also, logging could include the worker's pid but I'm not sure if that's useful.