### PR TITLE
Include timestamps with logs.

### DIFF
--- a/src/manet.js
+++ b/src/manet.js
@@ -37,7 +37,8 @@ function initLogging(conf) {
     logger.add(logger.transports.Console, {
         level: conf.level || DEF_LOGGER_LEVEL,
         silent: conf.silent || DEF_LOGGER_SILENT,
-        colorize: true
+        colorize: true,
+        timestamp: true
     });
 }
 


### PR DESCRIPTION
Logs are of much more value when they include timestamps. The timestamp is UTC, feel free to change this to local time if you think that's clearer or more useful.

Note that getting the log level to be colorized is a bit ugly, see https://github.com/winstonjs/winston/issues/603.