### PR TITLE
Use crypto module to limit file name length with sha1

### DIFF
--- a/src/capture.js
+++ b/src/capture.js
@@ -6,6 +6,8 @@ var _ = require('lodash'),
     path = require('path'),
     squirrel = require('squirrel'),
     utils = require('./utils'),
+    crypto = require('crypto'),
+    shasum = crypto.createHash('sha1'),
 
     SCRIPT_FILE = 'scripts/screenshot.js',
 
@@ -16,9 +18,11 @@ var _ = require('lodash'),
 
 /* Configurations and options */
 
-function outputFile(options, conf, base64) {
+function outputFile(options, conf) {
+    shasum.update(JSON.stringify(options));
+    var sha1 = shasum.digest('hex');
     var format = options.format || DEF_FORMAT;
-    return conf.storage + path.sep + base64 + '.' + format;
+    return conf.storage + path.sep + sha1 + '.' + format;
 }
 
 function cliCommand(config) {
@@ -110,7 +114,7 @@ function screenshot(options, config, onFinish) {
     var conf = createConfig(options, config),
         opts = createOptions(options, config),
         base64 = utils.encodeBase64(opts),
-        file = outputFile(opts, conf, base64),
+        file = outputFile(opts, conf),
 
         retrieveImageFromStorage = function () {
             logger.debug('Take screenshot from file storage: %s', base64);

--- a/src/capture.js
+++ b/src/capture.js
@@ -6,8 +6,6 @@ var _ = require('lodash'),
     path = require('path'),
     squirrel = require('squirrel'),
     utils = require('./utils'),
-    crypto = require('crypto'),
-    shasum = crypto.createHash('sha1'),
 
     SCRIPT_FILE = 'scripts/screenshot.js',
 
@@ -19,8 +17,7 @@ var _ = require('lodash'),
 /* Configurations and options */
 
 function outputFile(options, conf) {
-    shasum.update(JSON.stringify(options));
-    var sha1 = shasum.digest('hex');
+    var sha1 = require('crypto').createHash('sha1').update(JSON.stringify(options)).digest('hex');
     var format = options.format || DEF_FORMAT;
     return conf.storage + path.sep + sha1 + '.' + format;
 }

--- a/test/manet.js
+++ b/test/manet.js
@@ -117,11 +117,10 @@ describe('manet', function () {
                 checkDelay = checkApiCall({
                     delay: 100
                 }),
-//                TODO: return this test after fixing https://github.com/vbauer/manet/issues/10
-//                checkAgent = checkApiCall({
-//                    agent: 'Mozilla/5.0 (compatible, MSIE 11, ' +
-//                        'Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko'
-//                }),
+                checkAgent = checkApiCall({
+                    agent: 'Mozilla/5.0 (compatible, MSIE 11, ' +
+                        'Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko'
+                }),
                 checkJs = checkApiCall({
                     js: false
                 }),
@@ -144,7 +143,7 @@ describe('manet', function () {
                     checkForce,
                     checkQualityAndFormat,
                     checkDelay,
-//                    checkAgent,
+                    checkAgent,
                     checkJs,
                     checkImages,
                     stopServer


### PR DESCRIPTION
Fixes #10 

#10 issue is well known and seems to impact a lot of users of this library.

We tried Manet in our stack and, while being an amazing project, it does sadly fail on a large number of URL which are too long.
This PR represents an easy way to fix that issue.

Sha1 algorithm, even if could give some collisions in theory seems a good compromise between simplicity and efficiency.