### PR TITLE
Configured host and port has priority over cloud ENV one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,8 @@ tmp/
 *.ipr
 *.iws
 
+# Netbeans IDE
+nbproject/
+
 # Example project
 example/*.png

--- a/src/config.js
+++ b/src/config.js
@@ -100,8 +100,8 @@ function load() {
 
     config.cache = Math.max(config.cache, 0);
     config.storage = path.resolve(config.storage || os.tmpdir());
-    config.host = cloudEnv.get(ENV_IP, config.host);
-    config.port = cloudEnv.get(ENV_PORT, config.port);
+    config.host = config.host || cloudEnv.get(ENV_IP);
+    config.port = config.port || cloudEnv.get(ENV_PORT);
     config.path = confPath;
 
     return config;


### PR DESCRIPTION
Configured host and port has priority over cloud ENV one, this is imp…ortat if you want to run manet service as part of another service inside one container.

This change would currently break all manet instanced which are left with default config and are running inside cloud container. Proposed solution is to either comment HOST and PORT in default.yaml config to always load from cloud env first for current users or to introduce some config property that would force to use configured HOST and PORT instead of cloud-env one.

Why do I need this? Because I need to run manet inside a docker container which is a service on its own.  And with current implementation it always maps out via mapped port. But I need my service to be mapped out and manet service to be hidden.