### PR TITLE
Added new captureOnCallback option

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -9,12 +9,14 @@
         'user', 'password',
         'callback', 'headers', 'clipRect',
         'force', 'selector',
-        'engine'
+        'engine',
+        'captureOnCallback'
     ];
 
     function cleanBoolValue(name, value) {
         return ((value && (name === 'js' || name === 'images')) ||
-                (!value && name === 'force')) ? null : value;
+                (!value && name === 'force') ||
+                (!value && name === 'captureOnCallback')) ? null : value;
     }
 
     function readOptions() {

--- a/public/usage.html
+++ b/public/usage.html
@@ -85,6 +85,11 @@
                 </div>
 
                 <div class="pure-control-group">
+                    <label for="captureOnCallback" class="pure-checkbox">Capture on callback</label>
+                    <input id="captureOnCallback" name="captureOnCallback" type="checkbox">
+                </div>
+
+                <div class="pure-control-group">
                     <label for="images" class="pure-checkbox">Enable images</label>
                     <input id="images" name="images" type="checkbox" checked>
                 </div>

--- a/src/options.js
+++ b/src/options.js
@@ -41,7 +41,8 @@ function createSchema() {
                 secure: joi.boolean(),
                 expires: joi.string()
             })
-        )
+        ),
+        captureOnCallback: joi.boolean()
     });
 }
 


### PR DESCRIPTION
This pull request implements a solution to issue #11 .

I am not sure whether `captureOnCallback` is the best name, but `callback` was already taken.

I tested this feature using both phantom and slimer engines and it seems to work great.

I used the following url as the test page: 
https://presentation-ngwjsmdjlf.now.sh

```
<html>
  <head></head>
  <body>
    <h1 id="heading">My Content!</h1>
    <script>
      var h1 = document.getElementById('heading');


      // When the page load event fires, update text and make it red

      window.addEventListener('load', function() {
        h1.innerText = 'onLoad!';
        h1.style.color = 'red';
      });

      function duration() {
        var d = null;
        var parts = location.search.split('?t=');
        if (parts.length > 0) {
          d = parseInt(parts[parts.length-1], 10);
        }
        return isNaN(d) ? 0 : d;
      }


      // When this timeout fires, update text, make it green,
      // then tell PhantomJS we are ready!

      setTimeout(function() {
        h1.innerText = 'page is ready!';
        h1.style.color = 'green';
        if (typeof window.callPhantom === 'function') {
          window.callPhantom({ hello: 'world' });
        }
      }, duration());
      </script>
  </body>
</html>
```

I am happy to make changes if needed.